### PR TITLE
Create a url hash that shows an item's details

### DIFF
--- a/differences.txt
+++ b/differences.txt
@@ -30,4 +30,6 @@ Less noticeable changes
 - The official page shows two scrollbars when a item preview modal is opened. This page uses one instead.
 - The official site has CLS (cumulative layout shift) on its item preview modal. Meaning, when the modal’s image isn’t loaded, elements such as the description and “show details” button are at the top. When the image is finally loaded, those elements are shifted down. It is more noticeable on slower connections. This page avoids such CLS.
 - YouTube embeds load faster thanks to a package (lite-youtube-embed). They appear on screen almost (if not) as fast as images when fully loaded.
-- Clicking an item thumbnail brings up its preview modal, but also updates the URL and title to represent the item (as well as exiting out the modal). The forward and back buttons can then be used to switch between previously opened items.
+- Clicking an item thumbnail brings up its preview modal, but also updates the URL and title to represent the item (as well as exiting out the modal).
+- The forward and back buttons can be used to switch between previously opened items and the grid of items.
+- Showing the details of the item modifies the url to include a hash, "#details". So a link (with the hash) to an item can show details automatically.

--- a/src/ItemGrid.svelte
+++ b/src/ItemGrid.svelte
@@ -26,8 +26,15 @@
             <ItemThumbnailPlaceholder />
         {/each}
     {:else}
-        {#each items as item, index}
-            <ItemThumbnail {item} {showDescription} {showTags} focus={focusFirstItem && index === 0} blue={isBlue(index)} on:itemselect />
+        {#each items as item, i}
+            <ItemThumbnail
+                {item}
+                {showDescription}
+                {showTags}
+                focus={focusFirstItem && i === 0}
+                blue={isBlue(i)}
+                on:itemselect
+            />
         {/each}
     {/if}
 </div>

--- a/src/ItemPreviewModal.svelte
+++ b/src/ItemPreviewModal.svelte
@@ -1,11 +1,12 @@
 <script>
     import { getBrowseUrlFromTag } from "./helpers.js";
-    import { onMount } from "svelte";
+    import { createEventDispatcher, onMount } from "svelte";
     import ItemPreview from "./ItemPreview.svelte";
     import ItemGrid from "./ItemGrid.svelte";
 
     export let item;
     export let otherItems;
+    export let showDetails = false;
 
     let {
         id,
@@ -22,23 +23,30 @@
         user
     } = item;
 
+    const DETAILS_VISIBILITY_EVENT = "detailsvisibilitychange";
     const Links = {
         SIGN_UP: "https://www.theglassfiles.com/users/sign_up",
         SIGN_IN: "https://www.theglassfiles.com/users/sign_in",
         // ITEM: `https://www.theglassfiles.com/browse/images/${id}/show`,
     };
 
-    let showDetails = false;
+    const dispatch = createEventDispatcher();
+
     let detailsButton;
 
     onMount(() => detailsButton.focus());
+
+    function onDetailsButtonClick() {
+        showDetails = !showDetails;
+        dispatch(DETAILS_VISIBILITY_EVENT, showDetails);
+    }
 </script>
 
 <div class="preview">
     <ItemPreview {item} width="720" height="480" includeLink />
     <div class="summary">
         <p>{summary}</p>
-        <button on:click={() => showDetails = !showDetails} bind:this={detailsButton}>
+        <button on:click={onDetailsButtonClick} bind:this={detailsButton}>
             {showDetails ? "Hide" : "Show"}
             <span class="red">Details</span>
         </button>

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,5 +1,7 @@
-function getPathFromItem(item) {
-    return item.media_type === "video" ? `/videos/${item.id}` : `/images/${item.id}`;
+function getPathFromItem(item, showDetails = false) {
+    const media = item.media_type === "video" ? "videos" : "images";
+    const hash = showDetails ? "#details" : "";
+    return `/${media}/${item.id}${hash}`;
 }
 
 function getGeneralMediaType(item) {


### PR DESCRIPTION
Clicking the `Show Details` button in the item preview modal adds a hash, `#details` to the URL.
That link can also cause the modal to open the details section itself, so a link with the hash could be saved/shared.