### PR TITLE
Indicate which item view is active

### DIFF
--- a/differences.txt
+++ b/differences.txt
@@ -8,6 +8,7 @@ Changes (compared to official TGF home page)
 
 Noticeable changes
 
+- The item navbar, where you choose to view descriptions, artworks, or views, indicates which is active with an underline.
 - Just like how the color of an item thumbnail alternate between red and blue, its border also matches the item color.
 - Hovering over items give the background color an alpha of 80%. The item's thumbnail is terefore visible but with a red/blue tint.
 - The item thumbnail’s image is slightly scaled up when hovered, making a zoom effect.

--- a/public/global.css
+++ b/public/global.css
@@ -27,7 +27,7 @@ button {
 	font-size: 1.5rem;
 	font-family: inherit;
 }
-button:hover:not([disabled]) {
+button:hover:not([disabled]), button.active {
 	text-decoration: underline;
 	cursor: pointer;
 }

--- a/src/ItemNavbar.svelte
+++ b/src/ItemNavbar.svelte
@@ -1,21 +1,35 @@
 <script>
     import { createEventDispatcher } from "svelte";
 
-    let dispatch = createEventDispatcher();
-
     const VIEW_EVENT = "viewchange";
+    const View = {
+        ARTWORKS: "artwork",
+        DESCRIPTIONS: "descriptions",
+        TAGS: "tags"
+    };
 
-    function onClick(type) {
+    let activeView = View.ARTWORKS;
+
+    const dispatch = createEventDispatcher();
+
+    function onClick(view) {
         return () => {
-            dispatch(VIEW_EVENT, type);
+            activeView = view;
+            dispatch(VIEW_EVENT, view);
         };
     }
 </script>
 
 <div class="navbar">
-    <button on:click={onClick("descriptions")}>View <span class="red">Descriptions</span></button>
-    <button on:click={onClick("artwork")}>View <span class="red">Artwork</span></button>
-    <button on:click={onClick("tags")}>View <span class="red">Tags</span></button>
+    <button on:click={onClick(View.DESCRIPTIONS)} class:active={activeView === View.DESCRIPTIONS}>
+        View <span class="red">Descriptions</span>
+    </button>
+    <button on:click={onClick(View.ARTWORKS)} class:active={activeView === View.ARTWORKS}>
+        View <span class="red">Artwork</span>
+    </button>
+    <button on:click={onClick(View.TAGS)} class:active={activeView === View.TAGS}>
+        View <span class="red">Tags</span>
+    </button>
     <button disabled>Shuffle <span class="red">Items</span></button>
 </div>
 


### PR DESCRIPTION
Indicates, with an underline, whether `View Descriptions`, `View Artworks`, or `View Tags` is active.